### PR TITLE
[#1] Use "do:" with single statement if/unless and def/defp

### DIFF
--- a/lib/check/do_single_expression.ex
+++ b/lib/check/do_single_expression.ex
@@ -17,22 +17,10 @@ defmodule CompassCredoPlugin.Check.DoSingleExpression do
         :ok
       end
 
-      def create_voucher(attrs \\ %{}),
-      do:
-        %Voucher{}
-        |> change_voucher(attrs)
-        |> Repo.insert()
-
       # Preferred
       if some_condition, do: "some_stuff"
 
       def validate_coupon(), do: :ok
-
-      def create_voucher(attrs \\ %{}) do
-        %Voucher{}
-        |> change_voucher(attrs)
-        |> Repo.insert()
-      end
       """
     ]
 

--- a/lib/check/do_single_expression.ex
+++ b/lib/check/do_single_expression.ex
@@ -1,0 +1,49 @@
+defmodule CompassCredoPlugin.Check.DoSingleExpression do
+  use Credo.Check,
+    base_priority: :normal,
+    tags: [:controversial],
+    category: :readability,
+    explanations: [
+      check: """
+      Use do: for single line if/unless statements
+
+      Prefer using the single-line function as long as mix format command satisfies to keep the function body just in one line.
+
+      # Less Preferred
+      if some_condition do
+        "some_stuff"
+      end
+
+      def validate_coupon() do
+        :ok
+      end
+
+      def create_voucher(attrs \\ %{}),
+      do:
+        %Voucher{}
+        |> change_voucher(attrs)
+        |> Repo.insert()
+
+      # Preferred
+      if some_condition, do: "some_stuff"
+
+      def validate_coupon(), do: :ok
+
+      def create_voucher(attrs \\ %{}) do
+        %Voucher{}
+        |> change_voucher(attrs)
+        |> Repo.insert()
+      end
+      """
+    ]
+
+  @impl true
+  def run(%SourceFile{} = source_file, params) do
+    a = Credo.Code.to_lines(source_file)
+    IO.inspect(a)
+
+    # issue_meta = IssueMeta.for(source_file, params)
+
+    # Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+end

--- a/lib/check/do_single_expression.ex
+++ b/lib/check/do_single_expression.ex
@@ -53,3 +53,18 @@ defmodule CompassCredoPlugin.Check.DoSingleExpression do
 
   defp traverse(ast, issues, _), do: {ast, issues}
 end
+
+# a = length([{:do,
+#  {:__block__, [],
+#   [
+#     {:=, [line: 7, column: 7],
+#      [{:a, [line: 7, column: 5], nil}, {:+, [line: 7, column: 11], [5, 7]}]},
+#     {:=, [line: 8, column: 7],
+#      [
+#        {:a, [line: 8, column: 5], nil},
+#        {:+, [line: 8, column: 11], [{:a, [line: 8, column: 9], nil}, 1]}
+#      ]},
+#     {:a, [line: 9, column: 5], nil}
+#   ]}}])
+
+#   # IO.inspect(a)

--- a/lib/check/do_single_expression.ex
+++ b/lib/check/do_single_expression.ex
@@ -53,7 +53,8 @@ defmodule CompassCredoPlugin.Check.DoSingleExpression do
 
   defp traverse({operation, meta, [name, body]} = ast, issues, issue_meta)
        when operation in @matching_operations do
-    if contains_single_expression?(body) and contains_do_and_end?(meta) do
+    if contains_single_expression?(body) and contains_do_and_end?(meta) and
+         total_body_lines(meta) <= 2 do
       trigger = "#{operation} #{elem(name, 0)}"
       {ast, Enum.reverse([issue_for(trigger, meta[:line], issue_meta) | issues])}
     else
@@ -62,6 +63,8 @@ defmodule CompassCredoPlugin.Check.DoSingleExpression do
   end
 
   defp traverse(ast, issues, _issue_meta), do: {ast, issues}
+
+  defp total_body_lines(meta), do: meta[:end][:line] - meta[:do][:line]
 
   defp contains_single_expression?(body) do
     case body[:do] do

--- a/lib/check/do_single_expression.ex
+++ b/lib/check/do_single_expression.ex
@@ -37,6 +37,8 @@ defmodule CompassCredoPlugin.Check.DoSingleExpression do
       """
     ]
 
+  @def_ops [:def, :defp, :if, :unless]
+
   @impl true
   def run(%SourceFile{} = source_file, params) do
     issue_meta = IssueMeta.for(source_file, params)
@@ -44,8 +46,10 @@ defmodule CompassCredoPlugin.Check.DoSingleExpression do
     Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
   end
 
-  defp traverse({:def, _meta, [_, [{_, {:__block__, _, _}}]]} = _ast, _issues, _issue_meta) do
-    IO.puts("Block function")
+  defp traverse({op_call, _meta, [_, [{_, {:__block__, _, _}}]]} = ast, issues, _issue_meta)
+       when op_call in @def_ops do
+    IO.puts("It contains __block__ in the AST")
+    {ast, issues}
 
     # a = Credo.Code.to_lines(ast)
     # IO.inspect(a)
@@ -53,18 +57,3 @@ defmodule CompassCredoPlugin.Check.DoSingleExpression do
 
   defp traverse(ast, issues, _), do: {ast, issues}
 end
-
-# a = length([{:do,
-#  {:__block__, [],
-#   [
-#     {:=, [line: 7, column: 7],
-#      [{:a, [line: 7, column: 5], nil}, {:+, [line: 7, column: 11], [5, 7]}]},
-#     {:=, [line: 8, column: 7],
-#      [
-#        {:a, [line: 8, column: 5], nil},
-#        {:+, [line: 8, column: 11], [{:a, [line: 8, column: 9], nil}, 1]}
-#      ]},
-#     {:a, [line: 9, column: 5], nil}
-#   ]}}])
-
-#   # IO.inspect(a)

--- a/lib/check/do_single_expression.ex
+++ b/lib/check/do_single_expression.ex
@@ -39,11 +39,17 @@ defmodule CompassCredoPlugin.Check.DoSingleExpression do
 
   @impl true
   def run(%SourceFile{} = source_file, params) do
-    a = Credo.Code.to_lines(source_file)
-    IO.inspect(a)
+    issue_meta = IssueMeta.for(source_file, params)
 
-    # issue_meta = IssueMeta.for(source_file, params)
-
-    # Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
   end
+
+  defp traverse({:def, _meta, [_, [{_, {:__block__, _, _}}]]} = _ast, _issues, _issue_meta) do
+    IO.puts("Block function")
+
+    # a = Credo.Code.to_lines(ast)
+    # IO.inspect(a)
+  end
+
+  defp traverse(ast, issues, _), do: {ast, issues}
 end

--- a/priv/.credo.exs
+++ b/priv/.credo.exs
@@ -6,6 +6,7 @@
         {CompassCredoPlugin.Check.DefdelegateOrder, []},
         {CompassCredoPlugin.Check.SingleModuleFile, []},
         {CompassCredoPlugin.Check.RepeatingFragments, []}
+        {CompassCredoPlugin.Check.DoSingleExpression, []},
       ]
     }
   ]

--- a/test/check/do_single_expression_test.exs
+++ b/test/check/do_single_expression_test.exs
@@ -52,12 +52,12 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
           :ok
         end
 
-        defp another_function() do
-          :ok
-        end
-
         def get_response() do
           {:ok, :response}
+        end
+
+        defp another_function() do
+          :ok
         end
       end
       """

--- a/test/check/do_single_expression_test.exs
+++ b/test/check/do_single_expression_test.exs
@@ -3,11 +3,15 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
 
   alias CompassCredoPlugin.Check.DoSingleExpression
 
-  describe "given two valid functions BUT the last IF statement contains a single expression with a do/end block" do
+  describe "given three valid functions BUT the last IF statement contains a single expression with a do/end block" do
     test "reports an issue on the IF statement only" do
       module_source_code = """
       defmodule CredoSampleModule do
         alias CredoSampleModule.AnotherModule
+
+        my_map = %{
+          a: 1
+        }
 
         def some_function() do
            a = 5 + 7
@@ -16,17 +20,19 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
 
         def some_other_function, do: :ok
 
-        if some_condition() do
+        if some_condition,
+          do: :ok
+
+        if some_other_condition() do
           :ok
         end
-
       end
       """
 
       module_source_code
       |> to_source_file()
       |> run_check(DoSingleExpression)
-      |> assert_issue(fn issue -> assert issue.trigger == "@if some_condition" end)
+      |> assert_issue(fn issue -> assert issue.trigger == "@if some_other_condition" end)
     end
   end
 
@@ -51,7 +57,6 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
         defp another_function() do
           :ok
         end
-
       end
       """
 
@@ -80,7 +85,6 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
             item_2
           ]
         end
-
       end
       """
 
@@ -91,7 +95,7 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
     end
   end
 
-  describe "given a function that contain a WHEN clause and has a single expression with a do/end block BUt still has a single line" do
+  describe "given a function that contains a WHEN clause and a single expression with a do/end block BUT still has a single line" do
     test "reports an issue on the when clause" do
       module_source_code = """
       defmodule CredoSampleModule do
@@ -106,32 +110,6 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
       |> to_source_file()
       |> run_check(DoSingleExpression)
       |> assert_issue(fn issue -> assert issue.trigger == "@def when" end)
-    end
-  end
-
-  describe "given two valid functions and a valid IF statement" do
-    test "does NOT report an issue" do
-      module_source_code = """
-      defmodule CredoSampleModule do
-        alias CredoSampleModule.AnotherModule
-
-        def some_function() do
-           a = 5 + 7
-           a + 5
-        end
-
-        def some_other_function(), do: :ok
-
-        if some_condition,
-          do: :ok
-
-      end
-      """
-
-      module_source_code
-      |> to_source_file()
-      |> run_check(DoSingleExpression)
-      |> refute_issues()
     end
   end
 end

--- a/test/check/do_single_expression_test.exs
+++ b/test/check/do_single_expression_test.exs
@@ -4,7 +4,7 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
   alias CompassCredoPlugin.Check.DoSingleExpression
 
   describe "given two valid functions BUT the last IF statement contains a single expression with a do/end block" do
-    test "reports an issue" do
+    test "reports an issue on the IF statement only" do
       module_source_code = """
       defmodule CredoSampleModule do
         alias CredoSampleModule.AnotherModule
@@ -26,7 +26,7 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
       module_source_code
       |> to_source_file()
       |> run_check(DoSingleExpression)
-      |> assert_issue()
+      |> assert_issue(fn issue -> assert issue.trigger == "@if some_condition" end)
     end
   end
 

--- a/test/check/do_single_expression_test.exs
+++ b/test/check/do_single_expression_test.exs
@@ -14,9 +14,9 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
            a + 5
         end
 
-        def some_other_function(), do: :ok
+        def some_other_function, do: :ok
 
-        if some_condition do
+        if some_condition() do
           :ok
         end
 
@@ -62,7 +62,7 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
     end
   end
 
-  describe "given a function that contains a single expression with a do/end block BUT it spans multiple lines" do
+  describe "given functions that contain a single expression with a do/end block BUT span multiple lines" do
     test "does NOT report an issue" do
       module_source_code = """
       defmodule CredoSampleModule do
@@ -74,6 +74,13 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
           |> Repo.insert()
         end
 
+        def get_items() do
+          [
+            item_1,
+            item_2
+          ]
+        end
+
       end
       """
 
@@ -81,6 +88,24 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
       |> to_source_file()
       |> run_check(DoSingleExpression)
       |> refute_issues()
+    end
+  end
+
+  describe "given a function that contain a WHEN clause and has a single expression with a do/end block BUt still has a single line" do
+    test "reports an issue on the when clause" do
+      module_source_code = """
+      defmodule CredoSampleModule do
+        def build_error_message(purchase, _attrs)
+            when purchase.product.is_shippable == false do
+          "Purchase's product is not shippable"
+        end
+      end
+      """
+
+      module_source_code
+      |> to_source_file()
+      |> run_check(DoSingleExpression)
+      |> assert_issue(fn issue -> assert issue.trigger == "@def when" end)
     end
   end
 

--- a/test/check/do_single_expression_test.exs
+++ b/test/check/do_single_expression_test.exs
@@ -3,7 +3,7 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
 
   alias CompassCredoPlugin.Check.DoSingleExpression
 
-  describe "when there is any defdelegate after the first function" do
+  describe "when there is any functions or if statements with a single line in the body" do
     test "reports an issue" do
       module_source_code = """
       defmodule CredoSampleModule do
@@ -11,20 +11,13 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
 
         @default_value 10
 
-        def validate_coupon() do
+        if some_condition do
           :ok
         end
 
-        def create_voucher(attrs \\ %{}),
-          do:
-            %Voucher{}
-            |> change_voucher(attrs)
-            |> Repo.insert()
-
-        def foo, do: IO.inspect("foo")
-
-        def some_func(),
-          do: IO.puts("hi")
+        def validate_coupon() do
+          :ok
+        end
 
       end
       """
@@ -32,7 +25,7 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
       # [issue] =
         module_source_code
         |> to_source_file()
-        |> run_check(SingleStatement)
+        |> run_check(DoSingleExpression)
 
         # IO.inspect(issue)
     end

--- a/test/check/do_single_expression_test.exs
+++ b/test/check/do_single_expression_test.exs
@@ -1,0 +1,40 @@
+defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
+  use Credo.Test.Case
+
+  alias CompassCredoPlugin.Check.DoSingleExpression
+
+  describe "when there is any defdelegate after the first function" do
+    test "reports an issue" do
+      module_source_code = """
+      defmodule CredoSampleModule do
+        alias CredoSampleModule.AnotherModule
+
+        @default_value 10
+
+        def validate_coupon() do
+          :ok
+        end
+
+        def create_voucher(attrs \\ %{}),
+          do:
+            %Voucher{}
+            |> change_voucher(attrs)
+            |> Repo.insert()
+
+        def foo, do: IO.inspect("foo")
+
+        def some_func(),
+          do: IO.puts("hi")
+
+      end
+      """
+
+      # [issue] =
+        module_source_code
+        |> to_source_file()
+        |> run_check(SingleStatement)
+
+        # IO.inspect(issue)
+    end
+  end
+end

--- a/test/check/do_single_expression_test.exs
+++ b/test/check/do_single_expression_test.exs
@@ -30,6 +30,28 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
     end
   end
 
+  describe "given a function that contains a single expression with a do/end block BUT it spans multiple lines" do
+    test "does NOT report an issue" do
+      module_source_code = """
+      defmodule CredoSampleModule do
+        alias CredoSampleModule.AnotherModule
+
+        def create_voucher() do
+          %Voucher{}
+          |> change_voucher(attrs)
+          |> Repo.insert()
+        end
+
+      end
+      """
+
+      module_source_code
+      |> to_source_file()
+      |> run_check(DoSingleExpression)
+      |> refute_issues()
+    end
+  end
+
   describe "given two valid functions and a valid IF statement" do
     test "does NOT report an issue" do
       module_source_code = """

--- a/test/check/do_single_expression_test.exs
+++ b/test/check/do_single_expression_test.exs
@@ -3,7 +3,7 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
 
   alias CompassCredoPlugin.Check.DoSingleExpression
 
-  describe "given two valid functions BUT the last IF statement contains a single expression" do
+  describe "given two valid functions BUT the last IF statement contains a single expression with a do/end block" do
     test "reports an issue" do
       module_source_code = """
       defmodule CredoSampleModule do

--- a/test/check/do_single_expression_test.exs
+++ b/test/check/do_single_expression_test.exs
@@ -9,17 +9,12 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
       defmodule CredoSampleModule do
         alias CredoSampleModule.AnotherModule
 
-        @default_value 10
-
         def some_function() do
-          a = 5 + 7
-          a = a + 1
-          a
+           a = 5 + 7
+           a + 5
         end
 
-        def some_other_function() do
-          :ok
-        end
+        def some_other_function(), do: :ok
 
         if some_condition do
           :ok
@@ -28,12 +23,10 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
       end
       """
 
-      # [issue] =
       module_source_code
       |> to_source_file()
       |> run_check(DoSingleExpression)
-
-      # IO.inspect(issue)
+      |> assert_issues()
     end
   end
 end

--- a/test/check/do_single_expression_test.exs
+++ b/test/check/do_single_expression_test.exs
@@ -11,11 +11,17 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
 
         @default_value 10
 
+        def some_other_function() do
+          a = 5 + 7
+          a = a + 1
+          a
+        end
+
         if some_condition do
           :ok
         end
 
-        def validate_coupon() do
+        def some_function() do
           :ok
         end
 
@@ -23,11 +29,11 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
       """
 
       # [issue] =
-        module_source_code
-        |> to_source_file()
-        |> run_check(DoSingleExpression)
+      module_source_code
+      |> to_source_file()
+      |> run_check(DoSingleExpression)
 
-        # IO.inspect(issue)
+      # IO.inspect(issue)
     end
   end
 end

--- a/test/check/do_single_expression_test.exs
+++ b/test/check/do_single_expression_test.exs
@@ -26,7 +26,7 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
       module_source_code
       |> to_source_file()
       |> run_check(DoSingleExpression)
-      |> assert_issues()
+      |> assert_issue()
     end
   end
 end

--- a/test/check/do_single_expression_test.exs
+++ b/test/check/do_single_expression_test.exs
@@ -11,17 +11,17 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
 
         @default_value 10
 
-        def some_other_function() do
+        def some_function() do
           a = 5 + 7
           a = a + 1
           a
         end
 
-        if some_condition do
+        def some_other_function() do
           :ok
         end
 
-        def some_function() do
+        if some_condition do
           :ok
         end
 

--- a/test/check/do_single_expression_test.exs
+++ b/test/check/do_single_expression_test.exs
@@ -30,6 +30,38 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
     end
   end
 
+  describe "given all the functions and if statements are invalid" do
+    test "reports an issue on all instances" do
+      module_source_code = """
+      defmodule CredoSampleModule do
+        alias CredoSampleModule.AnotherModule
+
+        def some_function() do
+           a = 5 + 7
+        end
+
+        if some_condition do
+          :ok
+        end
+
+        unless 1 > 2 do
+          :ok
+        end
+
+        defp another_function() do
+          :ok
+        end
+
+      end
+      """
+
+      module_source_code
+      |> to_source_file()
+      |> run_check(DoSingleExpression)
+      |> assert_issues(fn issues -> assert Enum.count(issues) == 4 end)
+    end
+  end
+
   describe "given a function that contains a single expression with a do/end block BUT it spans multiple lines" do
     test "does NOT report an issue" do
       module_source_code = """

--- a/test/check/do_single_expression_test.exs
+++ b/test/check/do_single_expression_test.exs
@@ -68,7 +68,7 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
 
         def get_response(), do: {:ok, :response}
 
-        def func(),
+        def some_other_function(),
           do: :ok
 
         defp another_function(), do: :ok

--- a/test/check/do_single_expression_test.exs
+++ b/test/check/do_single_expression_test.exs
@@ -3,7 +3,7 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
 
   alias CompassCredoPlugin.Check.DoSingleExpression
 
-  describe "when there is any functions or if statements with a single line in the body" do
+  describe "given two valid functions BUT the last IF statement contains a single expression" do
     test "reports an issue" do
       module_source_code = """
       defmodule CredoSampleModule do
@@ -27,6 +27,32 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
       |> to_source_file()
       |> run_check(DoSingleExpression)
       |> assert_issue()
+    end
+  end
+
+  describe "given two valid functions and a valid IF statement" do
+    test "does NOT report an issue" do
+      module_source_code = """
+      defmodule CredoSampleModule do
+        alias CredoSampleModule.AnotherModule
+
+        def some_function() do
+           a = 5 + 7
+           a + 5
+        end
+
+        def some_other_function(), do: :ok
+
+        if some_condition,
+          do: :ok
+
+      end
+      """
+
+      module_source_code
+      |> to_source_file()
+      |> run_check(DoSingleExpression)
+      |> refute_issues()
     end
   end
 end

--- a/test/check/do_single_expression_test.exs
+++ b/test/check/do_single_expression_test.exs
@@ -3,7 +3,57 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
 
   alias CompassCredoPlugin.Check.DoSingleExpression
 
-  describe "given valid functions, if statements and various declariations" do
+  describe "given all the if and unless statements are valid" do
+    test "does NOT report an issue" do
+      module_source_code = """
+      defmodule CredoSampleModule do
+        def some_function() do
+          a = 1
+          if some_condition, do: :ok
+        end
+
+        def some_other_function() do
+          a = 1
+          unless 1 > 2, do: :ok
+        end
+      end
+      """
+
+      module_source_code
+      |> to_source_file()
+      |> run_check(DoSingleExpression)
+      |> refute_issues()
+    end
+  end
+
+  describe "given all the if and unless statements are INVALID" do
+    test "reports an issue on all instances" do
+      module_source_code = """
+      defmodule CredoSampleModule do
+        def some_function() do
+          a = 1
+          if some_condition do
+            ok
+          end
+        end
+
+        def some_other_function() do
+          a = 1
+          unless 1 > 2 do
+            :ok
+          end
+        end
+      end
+      """
+
+      module_source_code
+      |> to_source_file()
+      |> run_check(DoSingleExpression)
+      |> assert_issues(fn issues -> assert Enum.count(issues) == 2 end)
+    end
+  end
+
+  describe "given all the functions are valid" do
     test "does NOT report an issue" do
       module_source_code = """
       defmodule CredoSampleModule do
@@ -18,12 +68,8 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
 
         def get_response(), do: {:ok, :response}
 
-        if some_condition,
+        def func(),
           do: :ok
-
-        unless 1 > 2, do: :ok
-
-        def some_other_function, do: :ok
 
         defp another_function(), do: :ok
       end
@@ -36,20 +82,12 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
     end
   end
 
-  describe "given all the functions and if statements are INVALID" do
+  describe "given all the functions are INVALID" do
     test "reports an issue on all instances" do
       module_source_code = """
       defmodule CredoSampleModule do
         def some_function() do
            a = 5 + 7
-        end
-
-        if some_condition do
-          :ok
-        end
-
-        unless 1 > 2 do
-          :ok
         end
 
         def get_response() do
@@ -65,7 +103,7 @@ defmodule CompassCredoPlugin.Check.DoSingleExpressionTest do
       module_source_code
       |> to_source_file()
       |> run_check(DoSingleExpression)
-      |> assert_issues(fn issues -> assert Enum.count(issues) == 5 end)
+      |> assert_issues(fn issues -> assert Enum.count(issues) == 3 end)
     end
   end
 


### PR DESCRIPTION
- Closes #1 

## What happened

Credo Check for a function or condition that contains a single `expression` **and** has a single `line` but the declaration has used `if/def ... end` block instead of `, do: `.

Compass [documentation](https://nimblehq.co/compass/development/code-conventions/elixir/#functions) also implicitly mentions that if an existing `do:` declaration spans multiple lines:

```elixir
def create_voucher(attrs \\ %{}),
  do:
    %Voucher{}
    |> change_voucher(attrs)
    |> Repo.insert()
```
then this should be moved into a `def ... end` block instead even though it only contains one expression it has multiple lines.

----------

Currently implemented:
- `Error` -> Single _expression_ with a `do/end` block that also contains just a single _line_

Could implement in future:
- `Error` -> Single _expression_ already with a `, do:` block BUT contains multiple _lines_ (move to `do/end` block instead?)

## Insight

- The `absence` of the `__block__` in the AST will be the determining point of whether it needs to be checked or not - if it is present it contains multiple expressions and will be skipped.
- The AST is the same for `def ... end` and `, do: ` so `Code.string_to_quoted!(token_metadata: true)` has been used for extra metadata for end block
- Line numbers in the AST meta refer the last line of an expression. If a 3 line pipe was used the line number for the `do` in the function will be that last line (one way to calculate how many lines a expression is for the above mentioned `do:` being too long)

<img width="1501" alt="Screenshot 2565-09-22 at 15 44 03" src="https://user-images.githubusercontent.com/8955671/191701357-927bc772-8827-4936-a179-68c4c0a5d141.png">
 
## Proof Of Work

<img width="1083" alt="Screenshot 2565-09-28 at 18 34 26" src="https://user-images.githubusercontent.com/8955671/192768850-b9549815-7e0b-4a9d-802b-817e44c6a387.png">

![Screenshot 2565-09-23 at 16 42 20](https://user-images.githubusercontent.com/8955671/191934401-61653194-e54e-413a-ac83-ad5779e6a31a.png)

![Screenshot 2565-09-23 at 16 42 29](https://user-images.githubusercontent.com/8955671/191934419-7d4a0b30-7f6c-453f-9e70-046f0fded514.png)

![Screenshot 2565-09-23 at 16 42 58](https://user-images.githubusercontent.com/8955671/191934430-cfa24287-bb89-4830-9877-45b2490876e2.png)
