### PR TITLE
[#3] Avoid repeating fragments in module names and namespaces

### DIFF
--- a/lib/check/repeating_fragments.ex
+++ b/lib/check/repeating_fragments.ex
@@ -37,9 +37,6 @@ defmodule CompassCredoPlugin.Check.RepeatingFragments do
     case Enum.at(body, 0) do
       {:__aliases__, meta, names} ->
         rise_issue_for_repeating_fragments(names, meta, issues, issue_meta)
-
-      _ ->
-        issues
     end
   end
 

--- a/lib/check/repeating_fragments.ex
+++ b/lib/check/repeating_fragments.ex
@@ -36,11 +36,11 @@ defmodule CompassCredoPlugin.Check.RepeatingFragments do
   defp issues_for_module_names(body, issues, issue_meta) do
     case Enum.at(body, 0) do
       {:__aliases__, meta, names} ->
-        rise_issue_for_repeating_fragments(names, meta, issues, issue_meta)
+        maybe_raise_issue_for_repeating_fragments(names, meta, issues, issue_meta)
     end
   end
 
-  defp rise_issue_for_repeating_fragments(names, meta, issues, issue_meta) do
+  defp maybe_raise_issue_for_repeating_fragments(names, meta, issues, issue_meta) do
     is_repeating? =
       names
       |> Enum.uniq()

--- a/lib/check/repeating_fragments.ex
+++ b/lib/check/repeating_fragments.ex
@@ -1,0 +1,64 @@
+defmodule CompassCredoPlugin.Check.RepeatingFragments do
+  use Credo.Check,
+    base_priority: :normal,
+    category: :readability,
+    explanations: [
+      check: """
+        Avoid repeating fragments in module names and namespaces.
+
+        # Don't
+        defmodule Todo.Todo do
+          ...
+        end
+
+        # Do
+        defmodule Todo.Item do
+          ...
+        end
+      """
+    ]
+
+  @impl true
+  def run(%SourceFile{} = source_file, params) do
+    issue_meta = IssueMeta.for(source_file, params)
+
+    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+  end
+
+  defp traverse({:defmodule, _meta, arguments} = ast, issues, issue_meta) do
+    {ast, issues_for_module_names(arguments, issues, issue_meta)}
+  end
+
+  defp traverse(ast, issues, _issue_meta) do
+    {ast, issues}
+  end
+
+  defp issues_for_module_names(body, issues, issue_meta) do
+    case Enum.at(body, 0) do
+      {:__aliases__, meta, names} ->
+        rise_issue_for_repeating_fragments(names, meta, issues, issue_meta)
+
+      _ ->
+        issues
+    end
+  end
+
+  defp rise_issue_for_repeating_fragments(names, meta, issues, issue_meta) do
+    is_repeating? =
+      names
+      |> Enum.uniq()
+      |> Enum.count() != Enum.count(names)
+
+    if is_repeating? do
+      [
+        format_issue(
+          issue_meta,
+          message: "Avoid repeating fragments in module names and namespaces.",
+          line_no: meta[:line]
+        )
+      ]
+    else
+      issues
+    end
+  end
+end

--- a/priv/.credo.exs
+++ b/priv/.credo.exs
@@ -3,7 +3,8 @@
     %{
       name: "default",
       checks: [
-        {CompassCredoPlugin.Check.DefdelegateOrder, []}
+        {CompassCredoPlugin.Check.DefdelegateOrder, []},
+        {CompassCredoPlugin.Check.RepeatingFragments, []},
       ]
     }
   ]

--- a/test/check/repeating_fragments_test.exs
+++ b/test/check/repeating_fragments_test.exs
@@ -1,0 +1,55 @@
+defmodule CompassCredoPlugin.Check.RepeatingFragmentsTest do
+  use Credo.Test.Case
+
+  alias CompassCredoPlugin.Check.RepeatingFragments
+
+  describe "when there repeating fragments in module names and namespaces" do
+    test "reports an issue" do
+      module_source_codes = [
+        # simple case
+        """
+          defmodule Todo.Todo do
+            alias CredoSampleModule.AnotherModule
+
+            def method, do: :ok
+          end
+        """,
+        # more advanced case
+        """
+          defmodule Todo.Something.Else.Todo do
+            alias CredoSampleModule.AnotherModule
+
+            def method, do: :ok
+          end
+        """
+      ]
+
+      Enum.each(module_source_codes, fn module_source_code ->
+        [issue] =
+          module_source_code
+          |> to_source_file()
+          |> run_check(RepeatingFragments)
+          |> assert_issue()
+
+        assert issue.check == RepeatingFragments
+      end)
+    end
+  end
+
+  describe "when there aren't repeating fragments in module names and namespaces" do
+    test "does not report an issue" do
+      module_source_code = """
+        defmodule Todo.Item do
+          alias CredoSampleModule.AnotherModule
+
+          def method, do: :ok
+        end
+      """
+
+      module_source_code
+      |> to_source_file()
+      |> run_check(RepeatingFragments)
+      |> refute_issues()
+    end
+  end
+end

--- a/test/check/repeating_fragments_test.exs
+++ b/test/check/repeating_fragments_test.exs
@@ -52,4 +52,17 @@ defmodule CompassCredoPlugin.Check.RepeatingFragmentsTest do
       |> refute_issues()
     end
   end
+
+  describe "when there aren't module name" do
+    test "does not report an issue" do
+      module_source_code = """
+        name = "abc"
+      """
+
+      module_source_code
+      |> to_source_file()
+      |> run_check(RepeatingFragments)
+      |> refute_issues()
+    end
+  end
 end


### PR DESCRIPTION
Resolves #3

## What happened

Add check to avoid repeating fragments in module names and namespaces.
 
## Proof Of Work

Create file:

```elixir
defmodule Todo.Todo do
  def method, do: :ok
end
```

Run check and error will be reported:
<img width="745" alt="image" src="https://user-images.githubusercontent.com/475367/191687110-cc088105-0912-421b-9f9f-457ea075352a.png">

