### PR TITLE
Relax credo dependency version requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,7 @@ defmodule CompassCredoPlugin.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:credo, "~> 1.6.6"},
+      {:credo, "~> 1.6", allow_pre: true},
       {:dialyxir, "~> 1.2.0", [only: [:dev], runtime: false]},
       {:excoveralls, "~> 0.14.6", [only: :test]},
       {:ex_doc, "~> 0.27", only: :dev, runtime: false}


### PR DESCRIPTION
## What happened

As the Credo is released the Release Candidate version. We need to allow the `rc` version of `credo` in case the project uses the latest version of credo
 
## Insight

The error when the project using the rc release of credo and `compass-credo-plugin`

![image](https://user-images.githubusercontent.com/948856/210960774-bb790be2-39aa-4f7d-ba29-bffc5f9175e7.png)

 
Version match experiment:

```sh
iex(6)> Version.match?("1.7.0", "~> 1.6.6", allow_pre: true)     
false
iex(7)> Version.match?("1.7.0", "~> 1.6", allow_pre: true)       
true
iex(8)> Version.match?("1.7.0-rc.1", "~> 1.6", allow_pre: true)
true
iex(9)> Version.match?("1.7.0-rc.1", "~> 1.6", allow_pre: false)
false
```
## Proof Of Work

The tests should pass.
